### PR TITLE
Remove apt-get remove apt-transport-https

### DIFF
--- a/6.9/Dockerfile
+++ b/6.9/Dockerfile
@@ -14,7 +14,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
  && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
  && apt-get update && apt-get install -y --no-install-recommends \
     yarn \
- && apt-get remove -y apt-transport-https \
  && rm -rf /var/lib/apt/lists/*
 
 RUN export CONSUL_TEMPLATE_VERSION=0.16.0 \


### PR DESCRIPTION
# Reviewers
- [ ] @jtrinklein 

<img width="530" alt="screen shot 2016-12-29 at 12 22 10 pm" src="https://cloud.githubusercontent.com/assets/3537127/21554125/ca69717e-cdc1-11e6-9518-93efd74aa05c.png">

I don't think we should be preventing dependent boxes from running apt-get update.