### PR TITLE
Remove yarn.list post apt-get install

### DIFF
--- a/6.9/Dockerfile
+++ b/6.9/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
  && apt-get update && apt-get install -y --no-install-recommends \
     yarn \
  && apt-get remove -y apt-transport-https \
+ && rm /etc/apt/sources.list.d/yarn.list \
  && rm -rf /var/lib/apt/lists/*
 
 RUN export CONSUL_TEMPLATE_VERSION=0.16.0 \


### PR DESCRIPTION
# Reviewers
- [ ] @jtrinklein 

<img width="530" alt="screen shot 2016-12-29 at 12 22 10 pm" src="https://cloud.githubusercontent.com/assets/3537127/21554327/9ae0e0d4-cdc3-11e6-8279-11d968d101ef.png">

this list adds a dependency on apt-transport-https to run apt-get update, which we delete in this image.  I don't think this is a requirement we should be putting on dependent docker images.